### PR TITLE
FIX: Unsupported lookbehind regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@origam/utils",
   "main": "dist/index.js",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "GPL-3.0",
   "files": [
     "dist"

--- a/src/utils/dateConversion.ts
+++ b/src/utils/dateConversion.ts
@@ -25,8 +25,13 @@ export function csToMomentFormat(csDateFormat: string | undefined) {
     return null;
   }
   return csDateFormat                       // Meaning of the replaced character in c#:
-    .replace(/(?<!d)d(?!d)/g, "D") // The day of the month, from 1 through 31., do not replace "ddd" and "dddd" those are valid day of week symbols
-    .replace(/(?<!d)dd(?!d)/g, "DD")
+    // The day of the month, from 1 through 31., do not replace "ddd" and "dddd" those are valid day of week symbols
+    // Implemented by a replacement fn. due to Safari lack of negative lookbehind support.
+    .replace(/d+/g, (capturedString) => 
+      capturedString.length <= 2 
+        ? capturedString.replace(/d/g,'D') 
+        : capturedString
+      ) 
     .replace(/f/g, "S") // The tenths of a second in a date and time value.
     .replace(/F/g, "S") // If non-zero, the tenths of a second in a date and time value.
     .replace(/K/g, "Z") // time zone


### PR DESCRIPTION
Lookbehind feature of regex ( e.g. `(?<!d)`) is not supported in older version of Safari. Replaced by a workaround.